### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I also provide a greasemonkey userscript. It will add a button on your marathon 
 Open your terminal and run:
 
 ```
-$ maril http://your.marathon.domain /your/application/id
+$ maril --host http://your.marathon.domain --id /your/application/id
 ```
 
 ## Development

--- a/lib/maril/generator.rb
+++ b/lib/maril/generator.rb
@@ -7,7 +7,7 @@ module Maril
 
     def generate
       app = fetch_app
-      cmd = [ 'docker run' ]
+      cmd = [ 'docker run --rm -it' ]
       app['env'].each do |k, v|
         cmd << "-e #{k}=#{v}"
       end
@@ -19,7 +19,7 @@ module Maril
       end
       cmd << app['container']['docker']['image']
       cmd << app['cmd'] if app['cmd']
-      cmd.join(" \\\n")
+      cmd.join(" ")
     end
 
     private

--- a/userscript/maril.user.js
+++ b/userscript/maril.user.js
@@ -21,7 +21,7 @@
       url: url,
       onload: function(response) {
         let app = JSON.parse(response.responseText).app;
-        let cmd = [ "docker run" ];
+        let cmd = [ "docker run --rm -it" ];
 
         for (var key in app.env) {
           cmd.push(`-e ${key}=${app.env[key]}`);
@@ -34,7 +34,7 @@
         });
         cmd.push(app.container.docker.image);
 
-        GM_setClipboard(cmd.join(" \\\n"));
+        GM_setClipboard(cmd.join(" "));
         alert("Already saved the docker run command into your clipboard.");
       },
       onerror: (response) => {

--- a/userscript/maril.user.js
+++ b/userscript/maril.user.js
@@ -4,7 +4,7 @@
 // @version      0.1.0
 // @description  Marathon Application Run In Local
 // @author       agate<agate.hao@gmail.com>
-// @match        http://PUT.YOUR.MARATHON.DOMAIN.HERE
+// @match        http://PUT.YOUR.MARATHON.DOMAIN.HERE/*
 // @grant        GM_xmlhttpRequest
 // @grant        GM_setClipboard
 // ==/UserScript==

--- a/userscript/maril.user.js.erb
+++ b/userscript/maril.user.js.erb
@@ -21,7 +21,7 @@
       url: url,
       onload: function(response) {
         let app = JSON.parse(response.responseText).app;
-        let cmd = [ "docker run" ];
+        let cmd = [ "docker run --rm -it" ];
 
         for (var key in app.env) {
           cmd.push(`-e ${key}=${app.env[key]}`);
@@ -34,7 +34,7 @@
         });
         cmd.push(app.container.docker.image);
 
-        GM_setClipboard(cmd.join(" \\\n"));
+        GM_setClipboard(cmd.join(" "));
         alert("Already saved the docker run command into your clipboard.");
       },
       onerror: (response) => {

--- a/userscript/maril.user.js.erb
+++ b/userscript/maril.user.js.erb
@@ -4,7 +4,7 @@
 // @version      <%= gemspec.version %>
 // @description  <%= gemspec.summary %>
 // @author       <%= gemspec.authors.map.with_index{ |a, i| "#{a}<#{gemspec.email[i]}>" }.join(", ") %>
-// @match        http://PUT.YOUR.MARATHON.DOMAIN.HERE
+// @match        http://PUT.YOUR.MARATHON.DOMAIN.HERE/*
 // @grant        GM_xmlhttpRequest
 // @grant        GM_setClipboard
 // ==/UserScript==


### PR DESCRIPTION
Made some updates:
- Updated the README
- Added `--rm -it` to the docker run.
  - `-it` allows interactive mode (otherwise, you cannot Ctrl-C your running image)
  - `--rm` cleans up the container on exit
- Joined the command by space instead of ` \\\n`.  <- that won't correctly paste into my terminal when it gets really long
- Added `/*` to the end of the marathon domain match to get it to work with Chrome tampermonkey.